### PR TITLE
docs: expand Arduino firmware best practices, add debugging & connectivity docs

### DIFF
--- a/blues-expert/lib/docs/arduino/best_practices.md
+++ b/blues-expert/lib/docs/arduino/best_practices.md
@@ -15,7 +15,7 @@ When creating a new Arduino project, there are a few best practices to follow to
 ## Suggestions
 
 - Do not introduce power management features until the user has confirmed that the sketch is working. Offer this as a follow up change.
-- Start with USB Serial debugging to demostrate that the sketch is working. After the user has confirmed that the sketch is working, this can be switched off.
+- Start with USB Serial debugging to demonstrate that the sketch is working. After the user has confirmed that the sketch is working, this can be switched off.
 - If the user asks for their data to be uploaded at a specific interval, ensure to set the `mode` to `periodic` in the `hub.set` request and the `outbound` to their desired interval.
 
 ## Example Basic Project
@@ -100,7 +100,10 @@ void setup()
     for (const size_t start_ms = millis(); !usbSerial && (millis() - start_ms) < usb_timeout_ms;)
         ;
 
-    usbSerial.println("Starting Arduino application for %s...", myProductID);
+    // Arduino's print()/println() do NOT support printf-style format specifiers.
+    // Print each part separately (or use snprintf() into a buffer, then println()).
+    usbSerial.print("Starting Arduino application for ");
+    usbSerial.println(myProductID);
 
     // For low-memory platforms, don't turn on internal Notecard logs.
 #ifndef NOTE_C_LOW_MEM
@@ -225,7 +228,7 @@ It does not make use of the Notecard's templated note feature, see below for mor
 
 ## Use Templates
 
-Use the `arduino_note_templates` tool to get the best practices for formatting a notes using templates for an Arduino project.
+Use the `firmware_best_practices` tool with the `templates` document type to get the best practices for formatting Notes using templates for an Arduino project.
 
 ## Using the STLinkV3 Debugger
 
@@ -235,3 +238,84 @@ If you want to use serial via the STLinkV3 debugger, you can use the following c
 HardwareSerial SerialVCP(PIN_VCP_RX, PIN_VCP_TX);
 #define debugSerial SerialVCP
 ```
+
+## Checking Notecard Responses
+
+The Notecard always returns a response to a `req`-style request. Firmware MUST check that response before trusting any value read from it. In `note-arduino` the pattern is:
+
+```cpp
+J *rsp = notecard.requestAndResponse(notecard.newRequest("card.temp"));
+if (notecard.responseError(rsp)) {
+    // The request failed, or the Notecard reported an "err" field.
+    notecard.logDebug("card.temp request failed\n");
+} else {
+    double temperature = JGetNumber(rsp, "value");
+    // ... use the value ...
+}
+notecard.deleteResponse(rsp); // ALWAYS free the response, even on error.
+```
+
+ALWAYS:
+
+- check `notecard.responseError(rsp)` before reading fields from a response. It returns `true` if the transaction failed OR the Notecard returned an `err` field.
+- call `notecard.deleteResponse(rsp)` for every response obtained via `requestAndResponse()`, on both the success and error paths. Skipping this leaks memory on the host.
+- guard against `NULL` before dereferencing any `J *` returned by `newRequest()`, `requestAndResponse()`, or `JAddObjectToObject()`. `note-arduino` allocates with `malloc()`, which can fail on low-memory hosts.
+
+Use the `firmware_best_practices` tool with the `debugging` document type for guidance on capturing the request/response traffic when a response check fails.
+
+## General Embedded Firmware Best Practices
+
+These practices apply to any Arduino/embedded firmware, not just the Notecard integration. Apply them alongside the Notecard-specific guidance above.
+
+NEVER:
+
+- block the `loop()` with long `delay()` calls in production firmware. `delay()` stalls the entire host and prevents it from servicing other work. Use non-blocking timing based on `millis()` instead (see below). Short `delay()` calls are acceptable in the initial "make it work" pass and in examples, but flag them for removal during optimisation.
+- perform work inside an interrupt service routine (ISR) beyond setting a `volatile` flag or reading a register. Do the real work back in `loop()`.
+- rely on dynamic allocation (`new`/`malloc`) in hot paths on memory-constrained hosts; repeated allocation/free cycles fragment the heap. Prefer statically-sized buffers.
+
+ALWAYS:
+
+- use non-blocking timing for periodic work so the host stays responsive:
+
+```cpp
+static uint32_t lastSampleMs = 0;
+const uint32_t sampleIntervalMs = 15000;
+
+void loop() {
+    uint32_t now = millis();
+    if (now - lastSampleMs >= sampleIntervalMs) {
+        lastSampleMs = now;
+        // take a reading, add a Note, etc.
+    }
+    // other non-blocking work can run here
+}
+```
+
+  Note that `millis()` overflows (wraps to 0) after ~49 days. The subtraction form above (`now - lastSampleMs`) is overflow-safe; comparing absolute timestamps (`now >= lastSampleMs + interval`) is NOT.
+
+- mark any variable shared between an ISR and `loop()` as `volatile`, and read/clear it with interrupts briefly disabled if it is larger than a single word.
+- give every blocking wait a timeout. Never spin on a sensor or peripheral "until ready" without a bound — a disconnected sensor will otherwise hang the device forever. The Notecard example uses a bounded wait for `Serial`:
+
+```cpp
+const size_t usb_timeout_ms = 3000;
+for (const size_t start_ms = millis(); !usbSerial && (millis() - start_ms) < usb_timeout_ms;)
+    ;
+```
+
+- initialise all variables, and prefer fixed-width integer types (`uint8_t`, `int32_t`, `uint32_t`) over `int`/`long` so behaviour is identical across host MCUs.
+- name magic numbers with `const`/`#define` (intervals, thresholds, buffer sizes, I2C addresses) rather than scattering literals through the code.
+- keep `setup()` and `loop()` thin: they should orchestrate calls into the project's library file, not contain sensor or Notecard logic directly (see the [Code Layout](#code-layout) guidance in the `index` document).
+
+TRY TO:
+
+- feed the hardware watchdog (if the host enables one) from the main loop, and let it reset the device if the loop ever stalls. Do not feed it from a timer/ISR, or a hung `loop()` will never be caught.
+- fail safe: on a repeated, unrecoverable error prefer a controlled restart over silently spinning. The Notecard can also restart a stalled host — see the `connectivity` document.
+- keep the state of the application in an explicit state machine (`enum State { ... }`) rather than deep nested conditionals once the sketch grows beyond a couple of tasks.
+- avoid floating-point math on hosts without an FPU where an integer/fixed-point representation will do; it is slower and larger.
+
+## Further Reading
+
+- Use the `firmware_best_practices` tool with the `debugging` document type for logging, trace mode, and serial monitoring.
+- Use the `firmware_best_practices` tool with the `connectivity` document type for tuning sync behaviour and receiving inbound data.
+- Use the `firmware_best_practices` tool with the `power_management` document type once the sketch is confirmed working.
+- Queries about `note-arduino` specifics should be made to the `docs_search` or `docs_search_expert` tool.

--- a/blues-expert/lib/docs/arduino/best_practices.md
+++ b/blues-expert/lib/docs/arduino/best_practices.md
@@ -261,6 +261,8 @@ ALWAYS:
 - call `notecard.deleteResponse(rsp)` for every response obtained via `requestAndResponse()`, on both the success and error paths. Skipping this leaks memory on the host.
 - guard against `NULL` before dereferencing any `J *` returned by `newRequest()`, `requestAndResponse()`, or `JAddObjectToObject()`. `note-arduino` allocates with `malloc()`, which can fail on low-memory hosts.
 
+For requests that must succeed, use the retrying variants instead of the plain calls: `sendRequestWithRetry(req, timeoutSeconds)` when you do not need the response, and `requestAndResponseWithRetry(req, timeoutSeconds)` when you do. Both retry until the request succeeds or the timeout lapses, and both delete the request object for you. This is especially important for the first request on cold boot (see the [Code Layout](#code-layout) guidance in the `index` document) and for any request the application cannot proceed without.
+
 Use the `firmware_best_practices` tool with the `debugging` document type for guidance on capturing the request/response traffic when a response check fails.
 
 ## General Embedded Firmware Best Practices

--- a/blues-expert/lib/docs/arduino/connectivity.md
+++ b/blues-expert/lib/docs/arduino/connectivity.md
@@ -1,0 +1,108 @@
+# Arduino Notecard Connectivity
+
+This document covers how to tune when and how the Notecard connects to Notehub, how to force a sync, and how to receive inbound data. It complements the `best_practices` document — apply the Notecard integration patterns there first.
+
+## Choosing a Sync Mode
+
+The `hub.set` request controls how the Notecard connects to Notehub. Set it once during initialisation. The `mode`, `outbound`, and `inbound` arguments are **persistent** — they are retained across restarts and across later `hub.set` requests that omit them.
+
+- `continuous` — the Notecard keeps a live session with Notehub. Lowest latency, highest power draw. Use for mains-powered devices or during development for easy debugging.
+- `periodic` — the Notecard connects on a schedule (see `outbound`/`inbound`). This is the correct default for battery-powered devices.
+- `minimum` — the Notecard only connects when explicitly told to via `hub.sync`. Lowest power.
+- `off` — no automatic connections.
+
+```cpp
+J *req = notecard.newRequest("hub.set");
+JAddStringToObject(req, "product", myProductID);
+JAddStringToObject(req, "mode", "periodic");
+JAddNumberToObject(req, "outbound", 60); // upload pending Notes at most every 60 minutes
+JAddNumberToObject(req, "inbound", 240); // check for inbound Notes at most every 240 minutes
+notecard.sendRequestWithRetry(req, 5);
+```
+
+ALWAYS:
+
+- start development in `continuous` mode for easy debugging, and leave a comment telling the user to switch to `periodic` for their production power profile.
+- use `sendRequestWithRetry()` for the first `hub.set` on cold boot to absorb the hardware race condition (see the `index` document).
+
+## Understanding `outbound` and `inbound`
+
+- `outbound` is the maximum time (in minutes) the Notecard will hold pending outbound Notes before connecting to upload them.
+- `inbound` is how often (in minutes) the Notecard connects to check for data queued for the device in Notehub.
+
+Set these to the largest values your application can tolerate — larger intervals mean fewer connections and dramatically lower power and cellular data usage. Avoid very short intervals (< 5 minutes), which effectively force a continuous connection and can conflict with GPS/GNSS usage on the same Notecard.
+
+## Forcing an Immediate Sync
+
+Two mechanisms let you override the schedule when data must move now:
+
+- Add `"sync": true` to a `note.add` request to have the Notecard connect and upload immediately after enqueuing that Note. Use sparingly on battery-powered devices — each sync costs power.
+
+```cpp
+J *req = notecard.newRequest("note.add");
+JAddStringToObject(req, "file", "readings.qo");
+JAddBoolToObject(req, "sync", true); // upload this Note right away
+J *body = JAddObjectToObject(req, "body");
+if (body != NULL) {
+    JAddNumberToObject(body, "temperature", temperature);
+}
+notecard.sendRequest(req);
+```
+
+- Issue a `hub.sync` request to manually trigger a full sync of pending inbound and outbound Notefiles:
+
+```cpp
+J *req = notecard.newRequest("hub.sync");
+notecard.sendRequest(req);
+```
+
+  `hub.sync` accepts `"out": true` to sync only outbound Notefiles, `"in": true` for inbound only, and `"allow": true` to release the Notecard from a connectivity penalty box.
+
+## Checking Connection and Sync Status
+
+Use these read requests (never write configuration in a status check) to observe connectivity:
+
+- `hub.sync.status` — reports the state of the current or most recent sync attempt, including whether a sync is in progress and any error.
+- `hub.status` — reports the current connection state to Notehub.
+- `card.wireless` — reports cellular signal strength and modem state, useful when diagnosing poor connectivity.
+
+Check `notecard.responseError(rsp)` on each of these before reading fields, and always `deleteResponse(rsp)` (see the `best_practices` document).
+
+## Receiving Inbound Data
+
+To act on data or commands sent from Notehub to the device, poll an inbound (`.qi`) Notefile. Do this from the main loop on a non-blocking timer, not with a blocking `delay()`.
+
+Retrieve one Note at a time with `note.get`, deleting it as it is read:
+
+```cpp
+J *req = notecard.newRequest("note.get");
+JAddStringToObject(req, "file", "commands.qi");
+JAddBoolToObject(req, "delete", true); // remove the Note once retrieved
+
+J *rsp = notecard.requestAndResponse(req);
+if (notecard.responseError(rsp)) {
+    // No notes available (returns a {note-noexist} error) or the request failed.
+} else {
+    J *body = JGetObject(rsp, "body");
+    if (body != NULL) {
+        const char *command = JGetString(body, "command");
+        // ... act on the command ...
+    }
+}
+notecard.deleteResponse(rsp);
+```
+
+To process several queued Notes at once, use `note.changes` (which returns all pending Notes in the Notefile) instead of `note.get`. A common robust pattern is to send an acknowledgment Note back to a `.qo` Notefile after acting on a command, so the cloud application knows the action was applied.
+
+In `periodic` or `minimum` mode, inbound Notes only arrive on the `inbound` schedule or after a `hub.sync`. If your application needs prompt commands, either shorten `inbound`, call `hub.sync` when appropriate, or use inbound signals for low-latency delivery.
+
+## Resilience When Offline
+
+The Notecard's store-and-forward design means outbound Notes are queued locally and delivered when connectivity returns — the host does not need to manage retries for outbound data. For host-side robustness:
+
+- do not block the loop waiting for a connection; enqueue Notes and let the Notecard sync on its schedule.
+- consider the reserved environment variables that let the Notecard recover a stalled system: `_restart_host_no_activity_hours` restarts the connected host after no host requests have been received for the given number of hours, and `_restart_host_every_hours` restarts the host on a fixed interval. To restart the Notecard itself when it cannot reach Notehub, use `_restart_no_activity_hours`.
+
+## Further Reading
+
+Queries about connectivity, sync behaviour, or Notehub specifics should be made to the `docs_search` or `docs_search_expert` tool. Use the `api_docs` tool for the full argument list of `hub.set`, `hub.sync`, `note.get`, and `note.changes`.

--- a/blues-expert/lib/docs/arduino/connectivity.md
+++ b/blues-expert/lib/docs/arduino/connectivity.md
@@ -66,7 +66,7 @@ Use these read requests (never write configuration in a status check) to observe
 - `hub.status` — reports the current connection state to Notehub.
 - `card.wireless` — reports cellular signal strength and modem state, useful when diagnosing poor connectivity.
 
-Check `notecard.responseError(rsp)` on each of these before reading fields, and always `deleteResponse(rsp)` (see the `best_practices` document).
+Check `notecard.responseError(rsp)` on each of these before reading fields, and always `deleteResponse(rsp)` (see the `best_practices` document). To watch a sync progress live while debugging, use the `debugSyncStatus()` helper described in the `debugging` document.
 
 ## Receiving Inbound Data
 
@@ -95,6 +95,78 @@ notecard.deleteResponse(rsp);
 To process several queued Notes at once, use `note.changes` (which returns all pending Notes in the Notefile) instead of `note.get`. A common robust pattern is to send an acknowledgment Note back to a `.qo` Notefile after acting on a command, so the cloud application knows the action was applied.
 
 In `periodic` or `minimum` mode, inbound Notes only arrive on the `inbound` schedule or after a `hub.sync`. If your application needs prompt commands, either shorten `inbound`, call `hub.sync` when appropriate, or use inbound signals for low-latency delivery.
+
+## Interrupt-Driven Inbound With the ATTN Pin
+
+Polling in a fast loop wastes power and host cycles. When the host can spare a GPIO, prefer letting the Notecard interrupt the host only when an inbound Notefile actually changes. Wire the Notecard's `ATTN` pin to a host GPIO and use the `card.attn` request to arm a file-watch interrupt. This is the interrupt-driven pattern the General Embedded Firmware Best Practices section (in the `best_practices` document) refers to: the ISR does nothing but set a `volatile` flag, and all real work happens back in `loop()`.
+
+Arm the interrupt in `setup()` to fire when a specific inbound Notefile is modified. `mode` is a comma-separated list; `arm,files` clears any prior event, watches the Notefiles in `files`, and pulls `ATTN` low until one of them changes (or `seconds` elapses, if non-zero):
+
+```cpp
+#define ATTN_INPUT_PIN 5 // any interrupt-capable GPIO on the host
+#define INBOUND_QUEUE_NOTEFILE "my-inbound.qi"
+
+// Set by the ISR, read by loop(). MUST be volatile — it is shared with an
+// interrupt context (see the best_practices document).
+static volatile bool attnInterruptOccurred = false;
+
+void attnISR() {
+    attnInterruptOccurred = true; // do nothing else in the ISR
+}
+
+void armAttn() {
+    attnInterruptOccurred = false;
+    J *req = notecard.newRequest("card.attn");
+    JAddStringToObject(req, "mode", "arm,files");
+    const char *files[] = { INBOUND_QUEUE_NOTEFILE };
+    JAddItemToObject(req, "files", JCreateStringArray(files, 1));
+    JAddNumberToObject(req, "seconds", 120); // also wake at least every 2 min; 0 = no timeout
+    notecard.sendRequest(req);
+}
+
+void setup() {
+    // ... notecard.begin() and hub.set as usual ...
+    pinMode(ATTN_INPUT_PIN, INPUT);
+    attachInterrupt(digitalPinToInterrupt(ATTN_INPUT_PIN), attnISR, RISING);
+    armAttn();
+}
+```
+
+In `loop()`, do nothing until the flag is set, then drain the inbound Notefile and re-arm:
+
+```cpp
+void loop() {
+    if (!attnInterruptOccurred) {
+        return; // or sleep / do other non-blocking work
+    }
+    armAttn(); // re-arm before processing so no change is missed
+
+    // Drain all pending inbound Notes.
+    while (true) {
+        J *req = notecard.newRequest("note.get");
+        JAddStringToObject(req, "file", INBOUND_QUEUE_NOTEFILE);
+        JAddBoolToObject(req, "delete", true);
+        J *rsp = notecard.requestAndResponse(req);
+        // responseError is expected (and ends the loop) once the queue is
+        // empty: a {note-noexist} or {file-noexist} error just means "no more".
+        if (notecard.responseError(rsp)) {
+            notecard.deleteResponse(rsp);
+            break;
+        }
+        J *body = JGetObject(rsp, "body");
+        if (body != NULL) {
+            // ... act on the command ...
+        }
+        notecard.deleteResponse(rsp);
+    }
+}
+```
+
+Notes:
+
+- Re-arming with `arm,files` is non-idempotent (it briefly pulls `ATTN` high, then low again). To re-arm using the values from the initial arm without restating them, use `mode: "rearm"` instead.
+- To clear all ATTN monitors, send `mode: "disarm,-all"`.
+- `card.attn` requires a physical wire from the Notecard `ATTN` pin to the chosen host GPIO. `ATTN` can watch many other events too (motion, location fixes, environment-variable changes, USB power); use `docs_search` or the `api_docs` tool for the full `mode` list.
 
 ## Resilience When Offline
 

--- a/blues-expert/lib/docs/arduino/debugging.md
+++ b/blues-expert/lib/docs/arduino/debugging.md
@@ -48,6 +48,24 @@ notecard.logDebugf("temperature=%.2f C\n", temperature);   // printf-style forma
 
 Prefer `logDebugf()` when you need formatted values — unlike Arduino's `Serial.println()`, it accepts printf-style format specifiers. These helpers are no-ops when no debug stream is configured, so they are safe to leave in place.
 
+## Watching a Sync Complete
+
+When debugging connectivity, it is useful to watch a sync progress in real time rather than polling `hub.sync.status` by hand. `note-arduino` provides a helper for exactly this:
+
+```cpp
+// Poll the Notecard for sync status roughly every 1000 ms and print every
+// log level (-1 = all) to the debug stream until the sync settles.
+J *req = notecard.newRequest("hub.sync");
+notecard.sendRequest(req);
+
+while (notecard.debugSyncStatus(1000, -1)) {
+    // debugSyncStatus() returns true while there is pending sync activity to
+    // report, and prints each status line to the configured debug stream.
+}
+```
+
+`debugSyncStatus(pollFrequencyMs, maxLevel)` requires a debug output stream to have been set with `setDebugOutputStream()`. Use it during development only; remove it from production firmware since it blocks the loop while polling.
+
 ## Notecard Trace Mode
 
 For problems that the request/response traffic alone does not explain (connectivity, GPS acquisition, sync timing), enable Notecard **trace mode**. The Notecard then streams a detailed internal log of its activity to the debug output.

--- a/blues-expert/lib/docs/arduino/debugging.md
+++ b/blues-expert/lib/docs/arduino/debugging.md
@@ -1,0 +1,93 @@
+# Arduino Notecard Debugging
+
+Getting visibility into what the Notecard and host are doing is the fastest way to find problems. Start every new Arduino project with debug output enabled, confirm the behaviour is correct, and only then disable it (see the `best_practices` document).
+
+## Enabling Notecard Debug Output
+
+`note-arduino` can print every JSON request and response, plus the Notecard's own internal log messages, to a serial stream. Wire this up in `setup()`:
+
+```cpp
+#include <Notecard.h>
+
+#define usbSerial Serial
+
+Notecard notecard;
+
+void setup() {
+    usbSerial.begin(115200);
+    // Wait up to 3 seconds for the serial monitor to attach (non-blocking bound).
+    const size_t usb_timeout_ms = 3000;
+    for (const size_t start_ms = millis(); !usbSerial && (millis() - start_ms) < usb_timeout_ms;)
+        ;
+
+    // Route Notecard debug output (and JSON traffic) to the serial monitor.
+    // Guard low-memory hosts, where internal logs are compiled out.
+#ifndef NOTE_C_LOW_MEM
+    notecard.setDebugOutputStream(usbSerial);
+#endif
+
+    notecard.begin(); // I2C by default
+}
+```
+
+With `setDebugOutputStream()` set, opening the Arduino serial monitor at 115200 baud shows the full request/response traffic to and from the Notecard, which is the single most useful debugging tool for a Notecard project.
+
+ALWAYS:
+
+- make the debug stream easy for the user to disable (a single `#define` or a `#ifdef` guard), since it must be removed for low-power production firmware.
+- guard `setDebugOutputStream()` with `#ifndef NOTE_C_LOW_MEM` so the sketch still builds on low-memory hosts.
+
+## Logging From Your Own Code
+
+Use the Notecard's debug logging helpers so your application logs travel on the same stream as the Notecard's:
+
+```cpp
+notecard.logDebug("Sensor initialised\n");                 // fixed string
+notecard.logDebugf("temperature=%.2f C\n", temperature);   // printf-style formatting
+```
+
+Prefer `logDebugf()` when you need formatted values — unlike Arduino's `Serial.println()`, it accepts printf-style format specifiers. These helpers are no-ops when no debug stream is configured, so they are safe to leave in place.
+
+## Notecard Trace Mode
+
+For problems that the request/response traffic alone does not explain (connectivity, GPS acquisition, sync timing), enable Notecard **trace mode**. The Notecard then streams a detailed internal log of its activity to the debug output.
+
+```cpp
+J *req = notecard.newRequest("card.trace");
+JAddStringToObject(req, "mode", "on"); // use "off" to disable
+notecard.sendRequest(req);
+```
+
+Trace mode is verbose and increases power consumption, so enable it only while actively debugging and turn it `off` (or remove it) before shipping.
+
+## Debugging Over the STLinkV3
+
+On boards where the USB serial port is not available, you can route debug output over the STLinkV3 virtual COM port:
+
+```cpp
+HardwareSerial SerialVCP(PIN_VCP_RX, PIN_VCP_TX);
+#define debugSerial SerialVCP
+```
+
+Then pass `debugSerial` to `notecard.setDebugOutputStream(debugSerial)`.
+
+## Monitoring the Notecard Directly
+
+You do not always need the host to see what the Notecard is doing:
+
+- **In-browser terminal** — connect the Notecard over USB and use the Blues in-browser terminal to issue requests and read responses directly. This is invaluable for isolating whether a problem is in the Notecard configuration or in the host firmware.
+- **AUX serial / FTDI debug cable** — the Notecard's `AUX` pins can mirror request/response traffic. Configure them with `card.aux.serial` using `"mode": "req"` and connect an FTDI cable to watch the traffic on a second serial port. This is useful when the host's only serial port is already in use.
+
+## Common Debugging Checklist
+
+When a Notecard project is not behaving as expected:
+
+1. Confirm `setDebugOutputStream()` is set and the serial monitor is open at 115200 baud.
+2. Check `notecard.responseError(rsp)` on every response and log failures (see the `best_practices` document).
+3. Verify the `hub.set` `product`, `mode`, and interval arguments with a `hub.get` request.
+4. Check connectivity and sync state with `hub.sync.status` and `card.wireless` (see the `connectivity` document).
+5. If the issue is timing- or connection-related, enable `card.trace` mode.
+
+## Further Reading
+
+Queries about `note-arduino` debugging specifics should be made to the `docs_search` or `docs_search_expert` tool.

--- a/blues-expert/lib/docs/arduino/index.md
+++ b/blues-expert/lib/docs/arduino/index.md
@@ -35,7 +35,7 @@ ALWAYS:
 - use templates for notes and ensure that the data types are correct. ALWAYS use the `firmware_best_practices` tool with the `templates` document type for more information.
 - use the I2C interface for Notecard communication, unless instructed otherwise by the user.
 - use Blues Expert tools to check and validate Notecard requests and responses.
-- generate a header comment in bother the `.c` and the `.h` files that contains the following information:
+- generate a header comment in both the `.cpp` and the `.h` files that contains the following information:
 
 ```c
 /***************************************************************************
@@ -57,11 +57,22 @@ NEVER:
 
 - layer note-c calls within the user's application code. If the Notecard is used, it should be handled by a function in the newly created library file.
 
+## Available Documentation
+
+Retrieve any of the following with the `firmware_best_practices` tool, passing `sdk: arduino` and the `document_type` shown:
+
+- `best_practices` — project structure, a complete basic example, Notecard response checking, and general embedded firmware best practices. Read this first.
+- `templates` — using Note templates to minimise bandwidth. ALWAYS use templates for Notes.
+- `debugging` — enabling serial debug output, logging, Notecard trace mode, and monitoring traffic.
+- `connectivity` — tuning sync mode/intervals, forcing syncs, checking status, and receiving inbound data.
+- `sensors` — connecting common I2C sensors.
+- `power_management` — optimising for low power. Apply only after the sketch is confirmed working.
+
 ## Power Management
 
 Implement the initial changes following this guide and then ask the user if they would like to optimise the code for power management.
 
-- use the `firmware_best_practices` tool with the `best_practices` document type.
+- use the `firmware_best_practices` tool with the `power_management` document type.
 
 ## Further Reading
 

--- a/blues-expert/lib/docs/arduino/index.md
+++ b/blues-expert/lib/docs/arduino/index.md
@@ -5,6 +5,8 @@ It is a wrapper around the note-c library and provides a native Arduino interfac
 
 This library is recommended for Arduino-based devices, in particular those that use the Arduino IDE/CLI for project management, building, and flashing.
 
+Use this document to orient yourself, then follow the [Recommended Workflow](#recommended-workflow) below, pulling in detailed guidance from the `firmware_best_practices` tool as each step calls for it.
+
 ## Installing the note-arduino library
 
 If required, the user may wish to install the note-arduino library using the Arduino CLI.
@@ -15,6 +17,30 @@ If required, the user may wish to install the note-arduino library using the Ard
 arduino-cli lib install "Blues Wireless Notecard"
 ```
 
+## Before You Start — Gather Requirements
+
+Collect the following from the user BEFORE writing any code. Do not guess these — ask if they are not already known.
+
+- **REQUIRED: Product UID.** The `com.company.name:product` identifier that binds the device to a Notehub project. Without it, the firmware will build and run but data will never reach Notehub. If the user does not have one, guide them to claim one at [notehub.io](https://notehub.io) (see the [ProductUID guide](https://dev.blues.io/tools-and-sdks/samples/product-uid)) before proceeding.
+- **Hardware.** The host MCU and carrier board. Default to the Blues Swan (Feather) + Notecarrier-F unless the user says otherwise — several patterns (e.g. power management) assume a Notecarrier-F.
+- **Connection interface.** Default to I2C for the Notecard unless the user needs serial. If serial, ask which UART/port.
+- **Sensors and data.** What the user wants to measure, and the specific sensor parts. Prefer I2C sensors with an Adafruit Arduino library where possible.
+- **Sync cadence.** How often data must reach Notehub. This determines the `hub.set` `mode` and `outbound`/`inbound` intervals.
+
+## Recommended Workflow
+
+Work through these steps in order. Each step names the `document_type` to retrieve from the `firmware_best_practices` tool (pass `sdk: arduino`).
+
+1. **Scaffold the project.** Create the sketch directory, a `README.md`, and a separate library file for all Notecard code, following the [Code Layout](#code-layout) rules below.
+2. **Write the initial integration** — Notecard init (`hub.set`) plus a basic sensor-read-and-`note.add` loop. Start in `continuous` mode for easy debugging. Retrieve `best_practices` for a complete working example, Notecard response-checking, and general embedded firmware guidance. **Read this first.**
+3. **Use Note templates** for every Notefile to minimise bandwidth. Retrieve `templates`. ALWAYS use templates for Notes.
+4. **Add sensors.** Retrieve `sensors` for wiring and reading common I2C parts.
+5. **Confirm it works with debug output.** Retrieve `debugging` for serial output, logging, `card.trace` mode, and monitoring the request/response traffic. Verify the device is producing events in Notehub before optimising anything.
+6. **Tune connectivity.** Retrieve `connectivity` to switch to `periodic` mode, set the sync intervals to match the user's cadence, force syncs when needed, and receive inbound data.
+7. **Optimise for power — last.** Only after the sketch is confirmed working, ask the user if they want to reduce power consumption, then retrieve `power_management`.
+
+Throughout: validate every Notecard request with the `api_validate` tool, and use `docs_search` / `docs_search_expert` for anything not covered here.
+
 ## Code Layout
 
 When either creating a new project or retrofitting existing projects to use the Notecard, ensure that the following structures are present:
@@ -24,7 +50,7 @@ When either creating a new project or retrofitting existing projects to use the 
 - A 'init' function that initializes the Notecard, along with `hub.set` commands to configure the Notecard.
   - Before optimising the code, set the `mode` to `continuous` for easy debugging. Use a comment to indicate that the user should change this to `periodic` to fit their application.
 - The first `sendRequest()` call should instead be `sendRequestWithRetry()` to ensure that the request is retried if it fails. This is to address a potential race condition on cold boot.
-- Once the initial pass has been made, go to [power management](#power-management) to ensure that the Notecard is power efficient.
+- Once the initial pass has been made, optimise for power efficiency using the `power_management` document type (step 7 above).
 
 ## Design Patterns
 
@@ -56,23 +82,6 @@ TRY TO:
 NEVER:
 
 - layer note-c calls within the user's application code. If the Notecard is used, it should be handled by a function in the newly created library file.
-
-## Available Documentation
-
-Retrieve any of the following with the `firmware_best_practices` tool, passing `sdk: arduino` and the `document_type` shown:
-
-- `best_practices` — project structure, a complete basic example, Notecard response checking, and general embedded firmware best practices. Read this first.
-- `templates` — using Note templates to minimise bandwidth. ALWAYS use templates for Notes.
-- `debugging` — enabling serial debug output, logging, Notecard trace mode, and monitoring traffic.
-- `connectivity` — tuning sync mode/intervals, forcing syncs, checking status, and receiving inbound data.
-- `sensors` — connecting common I2C sensors.
-- `power_management` — optimising for low power. Apply only after the sketch is confirmed working.
-
-## Power Management
-
-Implement the initial changes following this guide and then ask the user if they would like to optimise the code for power management.
-
-- use the `firmware_best_practices` tool with the `power_management` document type.
 
 ## Further Reading
 

--- a/blues-expert/lib/handlers.go
+++ b/blues-expert/lib/handlers.go
@@ -19,7 +19,7 @@ type FirmwareEntrypointArgs struct {
 // FirmwareBestPracticesArgs defines the arguments for the firmware best practices tool
 type FirmwareBestPracticesArgs struct {
 	Sdk          string `json:"sdk" jsonschema:"The sdk to use for the firmware project. Must be one of: arduino, c, zephyr, python"`
-	DocumentType string `json:"document_type" jsonschema:"The type of documentation to retrieve (e.g., 'power_management', 'best_practices', 'sensors', 'templates')"`
+	DocumentType string `json:"document_type" jsonschema:"The type of documentation to retrieve (e.g., 'best_practices', 'templates', 'debugging', 'connectivity', 'sensors', 'power_management')"`
 }
 
 // RequestValidateArgs defines the arguments for the notecard request validation tool
@@ -95,7 +95,7 @@ func HandleFirmwareBestPracticesTool(ctx context.Context, request *mcp.CallToolR
 	if args.DocumentType == "" {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Error: document_type parameter is required and cannot be empty. Examples: 'power_management', 'best_practices', 'sensors', 'templates'"},
+				&mcp.TextContent{Text: "Error: document_type parameter is required and cannot be empty. Examples: 'best_practices', 'templates', 'debugging', 'connectivity', 'sensors', 'power_management'"},
 			},
 			IsError: true,
 		}, nil, nil

--- a/blues-expert/tools.go
+++ b/blues-expert/tools.go
@@ -48,7 +48,7 @@ func CreateFirmwareBestPracticesTool() *mcp.Tool {
 				},
 				"document_type": {
 					Type:        "string",
-					Description: "The type of documentation to retrieve (e.g., 'power_management', 'best_practices', 'sensors', 'templates')",
+					Description: "The type of documentation to retrieve (e.g., 'best_practices', 'templates', 'debugging', 'connectivity', 'sensors', 'power_management')",
 				},
 			},
 			Required: []string{"sdk", "document_type"},


### PR DESCRIPTION
## Summary

Improves the Arduino documentation served by the `firmware_best_practices` and `firmware_entrypoint` MCP tools: restructures the entrypoint into a guided workflow, fixes several errors in the existing docs, expands `best_practices.md`, adds two new document types, and mines the [note-arduino](https://github.com/blues/note-arduino) examples/API for additional patterns. All new content was grounded against the live Blues docs (`docs_search` / `api_docs`) — every Notecard request was API-verified before being documented.

## Firmware entrypoint (`index.md`)
Reframed the entrypoint (served by `firmware_entrypoint`) from a reference page into an orientation document that sequences the build:
- **Before You Start** — a preflight checklist of requirements to gather from the user (ProductUID [REQUIRED], hardware/carrier, interface, sensors, sync cadence).
- **Recommended Workflow** — an ordered set of steps, each pointing at the relevant `document_type`, ending with power optimisation.
- Folded the previously duplicated standalone Power Management and Available Documentation sections into the workflow.
- Preserved the Code Layout, Design Patterns, and header-comment blocks.

## Fixes to existing docs
- **`best_practices.md`**: corrected a printf-in-`println()` bug, replaced the nonexistent `arduino_note_templates` tool reference with `firmware_best_practices` + `templates`, and fixed a typo.
- **`index.md`**: fixed `.c`/`.h` → `.cpp`/`.h`, a typo, and corrected the Power Management section, which pointed at the wrong `document_type`.

## Expanded `best_practices.md`
- **Checking Notecard Responses** — the `responseError` / `deleteResponse` / `NULL`-guard pattern, plus the `sendRequestWithRetry` / `requestAndResponseWithRetry` retry variants.
- **General Embedded Firmware Best Practices** — non-blocking `millis()` timing (overflow-safe), ISR discipline / `volatile`, bounded waits, fixed-width types, watchdog, state machines, and heap-fragmentation avoidance.

## New document types
- **`debugging.md`** — `setDebugOutputStream`, `logDebug`/`logDebugf`, the `debugSyncStatus()` helper, `card.trace` mode, STLinkV3, AUX/FTDI and in-browser terminal monitoring, plus a debugging checklist.
- **`connectivity.md`** — `hub.set` mode/`outbound`/`inbound` tuning and persistence, forcing syncs (`sync:true`, `hub.sync`), status checks, polled inbound (`note.get`/`note.changes`), interrupt-driven inbound via the `ATTN` pin (`card.attn`), and offline resilience.

## From the note-arduino repo
- **Interrupt-driven inbound (`card.attn`)** added to `connectivity.md`. Note: the note-arduino example arms ATTN with a `reset` mode that no longer exists in the current API — documented the verified `arm,files` / `rearm` form instead.
- **`debugSyncStatus()`** added to `debugging.md` for watching a sync live.
- **Retry variants** (`sendRequestWithRetry` / `requestAndResponseWithRetry`) documented in `best_practices.md`.
- Deliberately deferred: a binary-transfer topic (Examples 8/9) and Outboard DFU (Example 10), which need note-c header / hardware grounding before they're safe to document.

## Discoverability
Since the handler reads `docs/<sdk>/<type>.md`, a new topic file is only reachable if something advertises it. Wired the new types into the entrypoint workflow in `index.md` and updated the `document_type` examples in `tools.go` and `handlers.go`.

## Verification
- `go build ./...` passes.
- A throwaway test confirmed all six `document_type` files + `index` resolve through the handler's exact embed read path (removed after verifying).

🤖 Generated with [Claude Code](https://claude.com/claude-code)