### PR TITLE
feat: add release versioning and gate AWS deploy to releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,12 +14,14 @@ env:
   IMAGE_NAME_ECR: /blues-dev/blues-expert-mcp
 
 jobs:
-  build-and-push:
+  # Build and push to GitHub Container Registry on every push to main, manual
+  # dispatch, and release. This is the general-purpose image used for testing
+  # and history; it never touches AWS.
+  ghcr:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -34,6 +36,49 @@ jobs:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_GHCR }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_GHCR }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./blues-expert/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+  # Deploy to AWS ECR ONLY when a versioned GitHub Release is published.
+  # AppRunner auto-deploys the `latest` tag, so `latest` is pushed here (in
+  # addition to the semver tags) to trigger the deploy.
+  ecr:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -50,16 +95,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.REGISTRY_GHCR }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME_GHCR }}
-            ${{ env.REGISTRY_ECR }}${{ env.IMAGE_NAME_ECR }}
+          images: ${{ env.REGISTRY_ECR }}${{ env.IMAGE_NAME_ECR }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -69,6 +110,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/blues-expert/Dockerfile
+++ b/blues-expert/Dockerfile
@@ -16,8 +16,13 @@ RUN go mod download
 # Copy source code from parent directory
 COPY ../ .
 
+# Version injected via -ldflags at build time (e.g. a release tag). Left empty
+# for ad-hoc builds so the binary falls back to the embedded VCS revision.
+ARG VERSION=
+
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./blues-expert/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+    -ldflags="-X main.version=${VERSION}" -o main ./blues-expert/
 
 # Runtime stage
 FROM alpine:latest

--- a/blues-expert/main.go
+++ b/blues-expert/main.go
@@ -70,7 +70,7 @@ func main() {
 	sessionManager = lib.NewSessionManager()
 
 	// Create a new MCP server
-	impl := &mcp.Implementation{Name: "Blues Expert MCP", Version: commit}
+	impl := &mcp.Implementation{Name: "Blues Expert MCP", Version: serverVersion()}
 	opts := &mcp.ServerOptions{
 		Instructions: "This MCP server provides expert guidance on using the Blues Notecard & Notehub. When using this tool for developing firmware, use the 'firmware_entrypoint' tool to get started. Otherwise, use the 'docs_search' or 'docs_search_expert' tool to search the Blues documentation.",
 		HasTools:     true,
@@ -78,7 +78,7 @@ func main() {
 	s := mcp.NewServer(impl, opts)
 
 	// Send initial startup log
-	log.Info().Msg("Blues Expert MCP server starting...")
+	log.Info().Str("version", serverVersion()).Msg("Blues Expert MCP server starting...")
 
 	// Add tools
 	firmwareEntrypointTool := CreateFirmwareEntrypointTool()

--- a/blues-expert/version.go
+++ b/blues-expert/version.go
@@ -2,7 +2,17 @@ package main
 
 import "runtime/debug"
 
-var commit = func() string {
+// version is injected at build time via -ldflags "-X main.version=<semver>".
+// It is empty for local builds (e.g. `go run`), in which case serverVersion()
+// falls back to the VCS revision recorded in the build info.
+var version string
+
+// serverVersion returns the semantic version injected at build time, falling
+// back to the git commit revision when no version was injected.
+func serverVersion() string {
+	if version != "" {
+		return version
+	}
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
 			if setting.Key == "vcs.revision" {
@@ -11,4 +21,4 @@ var commit = func() string {
 		}
 	}
 	return "unknown"
-}()
+}


### PR DESCRIPTION
## Summary

Adds semantic versioning to the Blues Expert MCP and restricts the AWS deploy so that **merging to `main` no longer updates production** — AWS is only updated when a versioned GitHub Release is published.

Previously a single workflow job pushed to **both** GHCR and AWS ECR on every push to `main`, so each merge auto-deployed via AppRunner's `latest` tag. And the MCP reported the raw git commit SHA as its version.

## Changes

**Versioning**
- `version.go`: adds a `version` variable injected at build time via `-ldflags "-X main.version=<semver>"`, falling back to the embedded VCS revision for local/ad-hoc builds. Exposed via `serverVersion()`.
- `main.go`: the MCP `Implementation.Version` now reports `serverVersion()`, and the version is logged on startup (so the live version is visible in AppRunner logs).
- `Dockerfile`: accepts a `VERSION` build arg and injects it via ldflags. The default is **empty**, which preserves the VCS-revision fallback for ad-hoc `docker build`.

**Deploy gating** (`docker.yml`) — split the single job into two:
| Job | Triggers | Pushes to |
|-----|----------|-----------|
| `ghcr` | push to `main`, `workflow_dispatch`, release | GitHub Container Registry only |
| `ecr` | **published release only** | AWS ECR (`semver` + `latest`) |

- The `ecr` job is guarded by `if: github.event_name == 'release'`.
- `latest` is pushed **unconditionally** in the `ecr` job (not `enable={{is_default_branch}}`, which is false on a tag ref) so AppRunner's auto-deploy on `latest` fires.
- Each job carries its own `permissions` block (`ghcr`: `packages: write`; `ecr`: `id-token: write` for AWS OIDC).
- Dropped the dead `type=ref,event=pr` tag (the workflow has no `pull_request` trigger).

## ⚠️ Behavioral change

After this merges:
- **Merging to `main` will no longer deploy to AWS.** The currently-running AppRunner image stays live until the first release.
- Deploys now require cutting a **GitHub Release with a `vX.Y.Z` tag** — that tag becomes the injected version and the ECR image tag.
- `workflow_dispatch` builds go to GHCR only, not ECR.

## How to release

Create a GitHub Release with a semver tag (e.g. `v1.0.0`). The `ecr` job builds, injects the version, and pushes `1.0.0` + `latest` to ECR, triggering the AppRunner deploy.

## Verification

- `go build ./blues-expert/...` ✅
- `go build -ldflags="-X main.version=v9.9.9"` ✅ and confirmed the string is embedded in the binary
- Workflow YAML parses; two jobs (`ghcr`, `ecr`) with the `ecr` gate confirmed
- Actions logic can only be fully exercised by the first real push/release

🤖 Generated with [Claude Code](https://claude.com/claude-code)